### PR TITLE
Add Team-based Entity with User and Organization Associations

### DIFF
--- a/lib/app/accounts.ex
+++ b/lib/app/accounts.ex
@@ -1,0 +1,112 @@
+defmodule App.Accounts do
+  @moduledoc """
+  Accounts context: organizations, users, teams and memberships.
+  """
+
+  import Ecto.Query, warn: false
+  alias App.Repo
+
+  alias App.Accounts.{Organization, User, Team, TeamMembership}
+
+  # Organizations
+
+  def list_organizations, do: Repo.all(Organization)
+
+  def get_organization!(id), do: Repo.get!(Organization, id)
+
+  def create_organization(attrs \\ %{}) do
+    %Organization{}
+    |> Organization.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_organization(%Organization{} = org, attrs) do
+    org
+    |> Organization.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_organization(%Organization{} = org), do: Repo.delete(org)
+
+  # Users
+
+  def list_users, do: Repo.all(User)
+
+  def list_org_users(org_id) do
+    from(u in User, where: u.organization_id == ^org_id)
+    |> Repo.all()
+  end
+
+  def get_user!(id), do: Repo.get!(User, id)
+
+  def create_user(attrs \\ %{}) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def move_user_to_org(%User{} = user, %Organization{} = org) do
+    update_user(user, %{organization_id: org.id})
+  end
+
+  def delete_user(%User{} = user), do: Repo.delete(user)
+
+  # Teams
+
+  def list_teams(org_id \\ nil) do
+    base = from(t in Team, order_by: t.name)
+
+    case org_id do
+      nil -> Repo.all(base)
+      id -> base |> where([t], t.organization_id == ^id) |> Repo.all()
+    end
+  end
+
+  def get_team!(id), do: Repo.get!(Team, id)
+
+  def create_team(attrs \\ %{}) do
+    %Team{}
+    |> Team.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_team(%Team{} = team, attrs) do
+    team
+    |> Team.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_team(%Team{} = team), do: Repo.delete(team)
+
+  # Team memberships
+
+  def add_user_to_team(%User{} = user, %Team{} = team, role \\ :member) do
+    %TeamMembership{}
+    |> TeamMembership.changeset(%{user_id: user.id, team_id: team.id, role: role})
+    |> Repo.insert()
+  end
+
+  def remove_user_from_team(%User{} = user, %Team{} = team) do
+    from(m in TeamMembership, where: m.user_id == ^user.id and m.team_id == ^team.id)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      membership -> Repo.delete(membership)
+    end
+  end
+
+  def list_team_members(%Team{} = team) do
+    from(u in User,
+      join: m in TeamMembership, on: m.user_id == u.id,
+      where: m.team_id == ^team.id,
+      select: %{user: u, role: m.role}
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/app/accounts/organization.ex
+++ b/lib/app/accounts/organization.ex
@@ -1,0 +1,21 @@
+defmodule App.Accounts.Organization do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "organizations" do
+    field :name, :string
+
+    has_many :users, App.Accounts.User
+    has_many :teams, App.Accounts.Team
+
+    timestamps()
+  end
+
+  def changeset(org, attrs) do
+    org
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 2)
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/app/accounts/team.ex
+++ b/lib/app/accounts/team.ex
@@ -1,0 +1,22 @@
+defmodule App.Accounts.Team do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "teams" do
+    field :name, :string
+
+    belongs_to :organization, App.Accounts.Organization
+    many_to_many :users, App.Accounts.User, join_through: App.Accounts.TeamMembership
+
+    timestamps()
+  end
+
+  def changeset(team, attrs) do
+    team
+    |> cast(attrs, [:name, :organization_id])
+    |> validate_required([:name, :organization_id])
+    |> validate_length(:name, min: 2)
+    |> unique_constraint([:organization_id, :name], name: :teams_org_id_name_index)
+    |> assoc_constraint(:organization)
+  end
+end

--- a/lib/app/accounts/team_membership.ex
+++ b/lib/app/accounts/team_membership.ex
@@ -1,0 +1,21 @@
+defmodule App.Accounts.TeamMembership do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "team_memberships" do
+    belongs_to :team, App.Accounts.Team
+    belongs_to :user, App.Accounts.User
+    field :role, Ecto.Enum, values: [:member, :admin], default: :member
+
+    timestamps()
+  end
+
+  def changeset(membership, attrs) do
+    membership
+    |> cast(attrs, [:team_id, :user_id, :role])
+    |> validate_required([:team_id, :user_id])
+    |> unique_constraint([:team_id, :user_id], name: :team_memberships_team_id_user_id_index)
+    |> assoc_constraint(:team)
+    |> assoc_constraint(:user)
+  end
+end

--- a/lib/app/accounts/user.ex
+++ b/lib/app/accounts/user.ex
@@ -1,0 +1,23 @@
+defmodule App.Accounts.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :email, :string
+    field :name, :string
+
+    belongs_to :organization, App.Accounts.Organization
+    many_to_many :teams, App.Accounts.Team, join_through: App.Accounts.TeamMembership
+
+    timestamps()
+  end
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:email, :name, :organization_id])
+    |> validate_required([:email, :organization_id])
+    |> validate_format(:email, ~r/^[^@\s]+@[^@\s]+\.[^@\s]+$/)
+    |> unique_constraint(:email)
+    |> assoc_constraint(:organization)
+  end
+end

--- a/priv/repo/migrations/20250930120000_create_organizations.exs
+++ b/priv/repo/migrations/20250930120000_create_organizations.exs
@@ -1,0 +1,13 @@
+defmodule App.Repo.Migrations.CreateOrganizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:organizations) do
+      add :name, :string, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:organizations, [:name])
+  end
+end

--- a/priv/repo/migrations/20250930120100_create_users.exs
+++ b/priv/repo/migrations/20250930120100_create_users.exs
@@ -1,0 +1,16 @@
+defmodule App.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :email, :string, null: false
+      add :name, :string
+      add :organization_id, references(:organizations, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:users, [:email])
+    create index(:users, [:organization_id])
+  end
+end

--- a/priv/repo/migrations/20250930120200_create_teams.exs
+++ b/priv/repo/migrations/20250930120200_create_teams.exs
@@ -1,0 +1,15 @@
+defmodule App.Repo.Migrations.CreateTeams do
+  use Ecto.Migration
+
+  def change do
+    create table(:teams) do
+      add :name, :string, null: false
+      add :organization_id, references(:organizations, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:teams, [:organization_id])
+    create unique_index(:teams, [:organization_id, :name], name: :teams_org_id_name_index)
+  end
+end

--- a/priv/repo/migrations/20250930120300_create_team_memberships.exs
+++ b/priv/repo/migrations/20250930120300_create_team_memberships.exs
@@ -1,0 +1,17 @@
+defmodule App.Repo.Migrations.CreateTeamMemberships do
+  use Ecto.Migration
+
+  def change do
+    create table(:team_memberships) do
+      add :team_id, references(:teams, on_delete: :delete_all), null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :role, :string, null: false, default: "member"
+
+      timestamps()
+    end
+
+    create index(:team_memberships, [:team_id])
+    create index(:team_memberships, [:user_id])
+    create unique_index(:team_memberships, [:team_id, :user_id], name: :team_memberships_team_id_user_id_index)
+  end
+end


### PR DESCRIPTION
This PR implements a new team-based entity structure within our application that associates users with organizations and teams. The following changes have been made:

1. **Models and Migrations:** Added models for Organizations, Users, Teams, and TeamMemberships with the necessary migrations to create corresponding database tables.
2. **Accounts Context:** Introduced functions to manage organizations, users, and teams including listing, creating, updating, and deleting.
3. **User and Team Relationships:** Implemented many-to-many relationships between users and teams through team memberships, allowing for user roles within teams.

These changes address the need for better organization and team management in our app, facilitating user association with specific organizations and teams.

---

> This pull request was co-created with Cosine Genie

Original Task: [phoenix-elm-starter/t1fdlt9h0uaf](https://cosine.sh/cosinedemo/phoenix-elm-starter/task/t1fdlt9h0uaf)
Author: Pandelis Zembashis
